### PR TITLE
directory: optimize parallel deserialization in `Directory::load`

### DIFF
--- a/src/system/directory.rs
+++ b/src/system/directory.rs
@@ -1,7 +1,7 @@
 use doomstack::{here, Doom, ResultExt, Top};
 #[cfg(feature = "benchmark")]
 use memmap::{Mmap, MmapMut, MmapOptions};
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::path::Path;
 #[cfg(feature = "benchmark")]
 use std::{
@@ -78,8 +78,6 @@ impl Directory {
             0
         };
 
-        let mut keycards = vec![None; capacity];
-
         let entries = database
             .iter()
             .map(|entry| -> Result<_, Top<_>> {
@@ -93,7 +91,7 @@ impl Directory {
             .collect::<Result<Vec<_>, _>>()?;
 
         let entries = entries
-            .into_par_iter()
+            .par_iter()
             .map(|(key, value)| -> Result<_, Top<_>> {
                 let id = if key.len() == 8 {
                     let mut buffer = [0u8; 8];
@@ -111,6 +109,8 @@ impl Directory {
                 Ok((id, keycard))
             })
             .collect::<Vec<_>>();
+
+        let mut keycards = vec![None; capacity];
 
         for entry in entries {
             let (id, keycard) = entry?;


### PR DESCRIPTION
I am not sure why, but it seems that using `.into_par_iter()` on the entries vector is not correctly optimized by the compiler in this case. Unnecessary moves led to significant overhead, which would cancel out the benefit of parallelization on large directories.

#### **Performance of `Directory::load`**
observed on 32_000_000 entries, with 144 cores  
  
||Before<br />`.into_par_iter()`|After<br />`.par_iter()`|
|-|-|-|
|open DB, read capacity|3s|3s|
|load `entries` Vec|33s|33s|
|deserialize (in parallel)|**33s**|**2s**|
|writing `keycards` Vec|7s|7s|
|**Total**|**76s**|**45s**|